### PR TITLE
Convert server ID and certificate expiry to "reserved" bytes.

### DIFF
--- a/draft-xaptum-xtt.md
+++ b/draft-xaptum-xtt.md
@@ -1313,13 +1313,15 @@ byte DAASignature[<size of signature for this algorithm>];
 
 ~~~
 struct {
-    ClientID id;
-    byte expiry[8];   /* YYYYMMDD in UTC, as ASCII-encoded numbers */
+    byte reserved[24];
     byte root_id[16];       /* ServerRootCertificate to use */
     LongtermKey public_key;
     LongtermSignature root_signature;
 } ServerCertificate;
 ~~~
+
+The client MUST NOT interpret the bytes in the `reserved` field of the server certificate;
+it is for the server's use only.
 
 ## Record Layer
 


### PR DESCRIPTION
The server ID and expiry fields in the server certificate are now
removed.
But, to maintain backward-compatibility, the region of the server
certificate that previously contained those two fields is now converted
to "reserved" space.

closes #5 and closes #7